### PR TITLE
Add description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# LeanCloudLiveKit-Android
+# LiveKit 直播+聊天 UI 套件 &middot; Android
+
+LiveKit 是由 [LeanCloud](http://leancloud.cn) 官方推出的基于 [LeanCloud 实时通信](https://leancloud.cn/docs/realtime_v2.html) 与 [七牛直播服务](http://developer.qiniu.com/article/pili/sdk/server-sdk.html) 的 UI 套件。它包含直播、文字聊天、弹幕、送礼物等界面，方便开发者为自己的项目快速植入直播与聊天功能，并灵活定制界面。直播与聊天的数据都保存在云端，支持 CDN 加速，开发者无需为数据的存储和访问速度而担忧。
+
+具体使用方法请阅读 [官方文档](https://leancloud.cn/docs/livekit-android.html)。


### PR DESCRIPTION
界面截屏要放在文字下方更明了，但不知图片文件放在哪里好。直接引用 URL（如 `https://leancloud.cn/docs/images/live_kit_android_login.jpg`）显示不出来。

@junwenfeng 请修订。